### PR TITLE
Give error details when confidence cannot parse config file

### DIFF
--- a/tasks/confidence.js
+++ b/tasks/confidence.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
           store.load(configDocument);
           output = store.get("/", criteria);
         } else {
-          grunt.log.warn('Could not validate document as a valid confidence document');
+          grunt.log.error('Error parsing document:\n',JSON.stringify(err));
         }
 
 


### PR DESCRIPTION
Minor logging change just to output the error to the console when confidence does not validate the config file. The error actually tells you what part of your file it didn't understand, so this is much more useful then a static response.
